### PR TITLE
Refactor status handling into modular files

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+return [
+    'ssh' => 'SSH',
+    'nginx' => 'Nginx',
+    'php-fpm' => 'PHP-FPM',
+];

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+date_default_timezone_set('Europe/Warsaw');
+
+require_once __DIR__ . '/helpers.php';
+require_once __DIR__ . '/system_metrics.php';
+require_once __DIR__ . '/services.php';
+require_once __DIR__ . '/status_snapshot.php';
+require_once __DIR__ . '/status_responder.php';

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Bezpieczne escapowanie ciągów znaków do HTML.
+ */
+function h(?string $value): string
+{
+    return htmlspecialchars($value ?? '', ENT_QUOTES, 'UTF-8');
+}
+
+/**
+ * Zamienia ilość sekund na prostą reprezentację tekstową.
+ */
+function formatDuration(int $seconds): string
+{
+    $days = intdiv($seconds, 86400);
+    $seconds %= 86400;
+    $hours = intdiv($seconds, 3600);
+    $seconds %= 3600;
+    $minutes = intdiv($seconds, 60);
+
+    $parts = [];
+    if ($days > 0) {
+        $parts[] = $days . ' d';
+    }
+    if ($hours > 0) {
+        $parts[] = $hours . ' h';
+    }
+    if ($minutes > 0) {
+        $parts[] = $minutes . ' min';
+    }
+    if (empty($parts)) {
+        $parts[] = 'mniej niż minuta';
+    }
+
+    return implode(' ', $parts);
+}

--- a/src/services.php
+++ b/src/services.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Zwraca status usługi systemd.
+ *
+ * @return array{label: string, service: string, status: string, class: string, details: string|null}
+ */
+function getServiceStatus(string $service, string $label): array
+{
+    $output = [];
+    $returnCode = 0;
+    $command = sprintf('systemctl is-active %s 2>&1', escapeshellarg($service));
+    @exec($command, $output, $returnCode);
+
+    $firstLine = strtolower(trim($output[0] ?? ''));
+    $fullOutput = trim(implode(' ', $output));
+
+    $statusLabel = 'Nieznany';
+    $cssClass = 'status-unknown';
+
+    switch ($firstLine) {
+        case 'active':
+            $statusLabel = 'Aktywna';
+            $cssClass = 'status-ok';
+            break;
+        case 'inactive':
+            $statusLabel = 'Nieaktywna';
+            $cssClass = 'status-off';
+            break;
+        case 'failed':
+            $statusLabel = 'Błąd';
+            $cssClass = 'status-error';
+            break;
+        case 'activating':
+            $statusLabel = 'Uruchamianie';
+            $cssClass = 'status-warn';
+            break;
+        case 'deactivating':
+            $statusLabel = 'Zatrzymywanie';
+            $cssClass = 'status-warn';
+            break;
+        default:
+            if ($fullOutput !== '') {
+                if (stripos($fullOutput, 'System has not been booted with systemd') !== false) {
+                    $statusLabel = 'Brak systemd';
+                    $cssClass = 'status-warn';
+                } elseif (stripos($fullOutput, 'not found') !== false) {
+                    $statusLabel = 'Nie znaleziono usługi';
+                    $cssClass = 'status-off';
+                } elseif (stripos($fullOutput, 'command not found') !== false) {
+                    $statusLabel = 'Polecenie niedostępne';
+                    $cssClass = 'status-warn';
+                } else {
+                    $statusLabel = $fullOutput;
+                }
+            }
+            break;
+    }
+
+    return [
+        'label' => $label,
+        'service' => $service,
+        'status' => $statusLabel,
+        'class' => $cssClass,
+        'details' => $fullOutput !== '' ? $fullOutput : null,
+    ];
+}
+
+/**
+ * Buduje listę statusów monitorowanych usług.
+ *
+ * @param array<string, string> $servicesToCheck
+ * @return array<int, array{label: string, service: string, status: string, class: string, details: string|null}>
+ */
+function collectServiceStatuses(array $servicesToCheck): array
+{
+    $serviceStatuses = [];
+
+    foreach ($servicesToCheck as $service => $label) {
+        $serviceStatuses[] = getServiceStatus($service, $label);
+    }
+
+    return $serviceStatuses;
+}

--- a/src/status_responder.php
+++ b/src/status_responder.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Obsługuje parametry zapytań statusu.
+ *
+ * @param array<string, string> $servicesToCheck
+ */
+function handleStatusRequest(?string $statusParam, array $servicesToCheck): bool
+{
+    switch ($statusParam) {
+        case 'json':
+            respondWithStatusJson($servicesToCheck);
+            return true;
+        case 'stream':
+            streamStatus($servicesToCheck);
+            return true;
+        default:
+            return false;
+    }
+}
+
+/**
+ * Wysyła pojedynczą odpowiedź JSON ze stanem.
+ *
+ * @param array<string, string> $servicesToCheck
+ */
+function respondWithStatusJson(array $servicesToCheck): void
+{
+    $snapshot = collectStatusSnapshot($servicesToCheck);
+    [$payload, $hasError] = encodeStatusSnapshot($snapshot);
+
+    header('Content-Type: application/json; charset=UTF-8');
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
+
+    if ($hasError) {
+        http_response_code(500);
+    }
+
+    echo $payload;
+}
+
+/**
+ * Strumieniuje stan w formacie Server-Sent Events.
+ *
+ * @param array<string, string> $servicesToCheck
+ */
+function streamStatus(array $servicesToCheck): void
+{
+    if (function_exists('set_time_limit')) {
+        @set_time_limit(0);
+    }
+
+    if (function_exists('ignore_user_abort')) {
+        @ignore_user_abort(true);
+    }
+
+    header('Content-Type: text/event-stream; charset=UTF-8');
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
+    header('Connection: keep-alive');
+    header('X-Accel-Buffering: no');
+
+    if (function_exists('ob_get_level')) {
+        while (ob_get_level() > 0) {
+            @ob_end_flush();
+        }
+    }
+
+    echo "retry: 5000\n\n";
+    @ob_flush();
+    @flush();
+
+    $streamInterval = 1;
+
+    while (true) {
+        if (function_exists('connection_aborted') && connection_aborted()) {
+            break;
+        }
+
+        $snapshot = collectStatusSnapshot($servicesToCheck);
+        [$payload] = encodeStatusSnapshot($snapshot);
+
+        echo "event: status\n";
+        echo "data: {$payload}\n\n";
+
+        @ob_flush();
+        @flush();
+
+        if ($streamInterval > 0) {
+            sleep($streamInterval);
+        }
+    }
+}

--- a/src/status_snapshot.php
+++ b/src/status_snapshot.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Zbiera aktualny zestaw danych do prezentacji.
+ *
+ * @param array<string, string> $servicesToCheck
+ * @return array{
+ *     time: string,
+ *     generatedAt: string,
+ *     cpuTemperature: ?string,
+ *     systemLoad: ?string,
+ *     uptime: ?string,
+ *     services: array<int, array{label: string, service: string, status: string, class: string, details: string|null}>
+ * }
+ */
+function collectStatusSnapshot(array $servicesToCheck): array
+{
+    $now = new DateTimeImmutable('now');
+
+    return [
+        'time' => $now->format('H:i:s'),
+        'generatedAt' => $now->format(DATE_ATOM),
+        'cpuTemperature' => getCpuTemperature(),
+        'systemLoad' => getSystemLoad(),
+        'uptime' => getUptime(),
+        'services' => collectServiceStatuses($servicesToCheck),
+    ];
+}
+
+/**
+ * Koduje dane stanu na potrzeby API.
+ *
+ * @return array{payload: string, hasError: bool}
+ */
+function encodeStatusSnapshot(array $snapshot): array
+{
+    $payload = json_encode($snapshot, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    if ($payload === false) {
+        $fallback = [
+            'error' => json_last_error_msg() ?: 'Nie można zakodować danych stanu',
+            'generatedAt' => date(DATE_ATOM),
+        ];
+
+        $fallbackPayload = json_encode($fallback, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if ($fallbackPayload === false) {
+            $fallbackPayload = "{\"error\":\"Nie można zakodować danych stanu\"}";
+        }
+
+        return [
+            'payload' => $fallbackPayload,
+            'hasError' => true,
+        ];
+    }
+
+    return [
+        'payload' => $payload,
+        'hasError' => false,
+    ];
+}

--- a/src/system_metrics.php
+++ b/src/system_metrics.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Odczytuje temperaturę CPU Raspberry Pi (w stopniach Celsjusza).
+ */
+function getCpuTemperature(): ?string
+{
+    $thermalPaths = [
+        '/sys/class/thermal/thermal_zone0/temp',
+        '/sys/devices/virtual/thermal/thermal_zone0/temp',
+    ];
+
+    foreach ($thermalPaths as $path) {
+        if (is_readable($path)) {
+            $raw = trim((string) @file_get_contents($path));
+            if ($raw !== '' && is_numeric($raw)) {
+                $temperature = (float) $raw;
+                if ($temperature > 1000) {
+                    $temperature /= 1000;
+                }
+
+                return number_format($temperature, 1, '.', ' ') . ' °C';
+            }
+        }
+    }
+
+    $commandOutput = @shell_exec('vcgencmd measure_temp 2>/dev/null');
+    if ($commandOutput && preg_match('/temp=([\d\.]+)/', $commandOutput, $matches)) {
+        $temperature = (float) $matches[1];
+        return number_format($temperature, 1, '.', ' ') . ' °C';
+    }
+
+    return null;
+}
+
+/**
+ * Zwraca średnie obciążenie systemu (1, 5, 15 minut).
+ */
+function getSystemLoad(): ?string
+{
+    if (!function_exists('sys_getloadavg')) {
+        return null;
+    }
+
+    $load = sys_getloadavg();
+    if (!is_array($load) || count($load) < 3) {
+        return null;
+    }
+
+    return sprintf('1 min: %.2f • 5 min: %.2f • 15 min: %.2f', $load[0], $load[1], $load[2]);
+}
+
+/**
+ * Odczytuje czas działania systemu.
+ */
+function getUptime(): ?string
+{
+    $output = @shell_exec('uptime -p 2>/dev/null');
+    if ($output) {
+        return trim($output);
+    }
+
+    $uptimeFile = '/proc/uptime';
+    if (is_readable($uptimeFile)) {
+        $contents = trim((string) @file_get_contents($uptimeFile));
+        if ($contents !== '') {
+            $parts = explode(' ', $contents);
+            if (isset($parts[0]) && is_numeric($parts[0])) {
+                return formatDuration((int) $parts[0]);
+            }
+        }
+    }
+
+    return null;
+}


### PR DESCRIPTION
## Summary
- extract HTML helpers, system metrics, service checks, snapshot building, and response handling into dedicated files autoloaded from a bootstrap
- move the list of monitored services into a separate configuration file for easier edits
- update the index entry point to delegate status API requests to the responder helpers and render the view from a collected snapshot

## Testing
- php -l public/index.php
- php -l src/helpers.php
- php -l src/system_metrics.php
- php -l src/services.php
- php -l src/status_snapshot.php
- php -l src/status_responder.php
- php -l src/bootstrap.php
- php -l config/services.php

------
https://chatgpt.com/codex/tasks/task_e_68c9bb0e9bb48331a0e58e20f7bd32cf