### PR TITLE
Add HTTP Basic Auth protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # RaspberryPiServer
+
+Prosty panel statusu dla Raspberry Pi napisany w PHP.
+
+## Ochrona dostępu (HTTP Basic Auth)
+
+Aplikacja może być chroniona prostą autoryzacją HTTP Basic. Dane logowania są pobierane
+z pliku `config/auth.php`, który odczytuje wartości ze zmiennych środowiskowych:
+
+- `APP_BASIC_AUTH_USER` – nazwa użytkownika,
+- `APP_BASIC_AUTH_PASSWORD` – hasło.
+
+Jeśli którakolwiek z wartości jest pusta lub niezdefiniowana, ochrona jest wyłączona.
+
+### Jak włączyć
+
+1. Ustaw zmienne środowiskowe (np. w konfiguracji usługi systemd lub pliku `.env` używanym przez serwer WWW):
+   ```bash
+   export APP_BASIC_AUTH_USER="twoj_login"
+   export APP_BASIC_AUTH_PASSWORD="bardzo_tajne_haslo"
+   ```
+2. Uruchom ponownie serwer WWW / PHP-FPM, aby nowe wartości zostały odczytane.
+
+Po włączeniu ochrona wymaga podania poprawnych poświadczeń przy każdej próbie dostępu
+(do czasu zapisania ich przez przeglądarkę). W przypadku błędnych danych aplikacja
+odpowie statusem HTTP `401` oraz nagłówkiem `WWW-Authenticate`, co poinformuje
+przeglądarkę o konieczności podania loginu i hasła.

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+$envUsername = getenv('APP_BASIC_AUTH_USER');
+$envPassword = getenv('APP_BASIC_AUTH_PASSWORD');
+
+$normalize = static function ($value): ?string {
+    if ($value === false) {
+        return null;
+    }
+
+    $trimmed = trim((string) $value);
+    return $trimmed !== '' ? $trimmed : null;
+};
+
+return [
+    'username' => $normalize($envUsername),
+    'password' => $normalize($envPassword),
+];

--- a/public/index.php
+++ b/public/index.php
@@ -3,8 +3,29 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../src/bootstrap.php';
 
+/** @var array{username: string|null, password: string|null} $authConfig */
+$authConfig = require __DIR__ . '/../config/auth.php';
+
 /** @var array<string, string> $servicesToCheck */
 $servicesToCheck = require __DIR__ . '/../config/services.php';
+
+$authUsername = $authConfig['username'] ?? null;
+$authPassword = $authConfig['password'] ?? null;
+
+if ($authUsername !== null && $authPassword !== null) {
+    $providedUsername = $_SERVER['PHP_AUTH_USER'] ?? null;
+    $providedPassword = $_SERVER['PHP_AUTH_PW'] ?? null;
+
+    $credentialsMatch = $providedUsername === $authUsername && $providedPassword === $authPassword;
+
+    if (!$credentialsMatch) {
+        header('WWW-Authenticate: Basic realm="RaspberryPiServer"');
+        header('Content-Type: text/plain; charset=utf-8');
+        http_response_code(401);
+        echo 'Unauthorized';
+        return;
+    }
+}
 
 $statusParam = isset($_GET['status']) ? (string) $_GET['status'] : null;
 if (handleStatusRequest($statusParam, $servicesToCheck)) {


### PR DESCRIPTION
## Summary
- add a configuration file for HTTP Basic Auth credentials loaded from environment variables
- enforce the credential check in `public/index.php` before handling status requests
- document how to enable the protection in the README

## Testing
- php -l public/index.php
- php -l config/auth.php

------
https://chatgpt.com/codex/tasks/task_e_68c9cdb898948331831314ef221812ab