### PR TITLE
Remove Chart.js dependency and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ zwracanych elementów parametrem `limit`, np. `?status=history&limit=120`.
 ### Wykres w interfejsie
 
 Front-end rysuje wykres temperatury CPU z wykorzystaniem elementu SVG generowanego przez
-JavaScript, dzięki czemu nie wymaga dodatkowych bibliotek ani dostępu do zewnętrznego CDN.
+JavaScript. Wykorzystuje wyłącznie natywne możliwości przeglądarki, więc aplikacja nie ładuje
+żadnych bibliotek zewnętrznych (np. Chart.js) ani zasobów z CDN.
 Wykres aktualizuje się automatycznie po wczytaniu strony, ręcznym odświeżeniu oraz podczas pracy
 w trybie strumieniowym. Jeżeli historia jest wyłączona lub niedostępna, panel wyświetli
 odpowiedni komunikat. Wygląd i zachowanie wykresu możesz dopasować, modyfikując pliki

--- a/public/index.php
+++ b/public/index.php
@@ -48,7 +48,6 @@ $serviceStatuses = $snapshot['services'];
   <meta charset="UTF-8">
   <title>Moja strona na Raspberry Pi</title>
   <link rel="stylesheet" href="styles.css">
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous"></script>
 </head>
 <body>
   <h1>Witaj na mojej stronie! 🎉</h1>


### PR DESCRIPTION
## Summary
- remove the Chart.js CDN script tag from the public index
- rely solely on the existing native SVG/JS implementation for the history chart
- document that the app no longer needs external CDN resources

## Testing
- rg "Chart"


------
https://chatgpt.com/codex/tasks/task_e_68c9e3c0f9c8833183daf306d8673263