### PR TITLE
Use constant-time comparison for basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Jeśli którakolwiek z wartości jest pusta lub niezdefiniowana, ochrona jest wy
 Po włączeniu ochrona wymaga podania poprawnych poświadczeń przy każdej próbie dostępu
 (do czasu zapisania ich przez przeglądarkę). W przypadku błędnych danych aplikacja
 odpowie statusem HTTP `401` oraz nagłówkiem `WWW-Authenticate`, co poinformuje
-przeglądarkę o konieczności podania loginu i hasła.
+przeglądarkę o konieczności podania loginu i hasła. Weryfikacja poświadczeń odbywa się
+przy użyciu funkcji `hash_equals`, dzięki czemu porównanie ma stały czas wykonania.
 
 ## Historia metryk
 

--- a/public/index.php
+++ b/public/index.php
@@ -13,10 +13,27 @@ $authUsername = $authConfig['username'] ?? null;
 $authPassword = $authConfig['password'] ?? null;
 
 if ($authUsername !== null && $authPassword !== null) {
-    $providedUsername = $_SERVER['PHP_AUTH_USER'] ?? null;
-    $providedPassword = $_SERVER['PHP_AUTH_PW'] ?? null;
+    $credentialsMatch = false;
 
-    $credentialsMatch = $providedUsername === $authUsername && $providedPassword === $authPassword;
+    $providedUsernameRaw = $_SERVER['PHP_AUTH_USER'] ?? null;
+    $providedPasswordRaw = $_SERVER['PHP_AUTH_PW'] ?? null;
+
+    if ($providedUsernameRaw !== null && $providedPasswordRaw !== null) {
+        $providedUsername = (string) $providedUsernameRaw;
+        $providedPassword = (string) $providedPasswordRaw;
+        $expectedUsername = (string) $authUsername;
+        $expectedPassword = (string) $authPassword;
+
+        if (
+            $providedUsername !== ''
+            && $providedPassword !== ''
+            && $expectedUsername !== ''
+            && $expectedPassword !== ''
+        ) {
+            $credentialsMatch = hash_equals($expectedUsername, $providedUsername)
+                && hash_equals($expectedPassword, $providedPassword);
+        }
+    }
 
     if (!$credentialsMatch) {
         header('WWW-Authenticate: Basic realm="RaspberryPiServer"');


### PR DESCRIPTION
## Summary
- compare provided HTTP Basic credentials with `hash_equals` to avoid timing differences
- skip calling `hash_equals` when credentials are missing or empty strings
- document the constant-time verification approach in the README

## Testing
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68c9e517fdcc8331b0e4cdb95586b417