### PR TITLE
Dodaj minimalny odstęp czasowy dla wpisów historii

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Możesz dostosować zachowanie za pomocą zmiennych środowiskowych:
   Ustaw wartość `0`, aby całkowicie wyłączyć zapisywanie historii.
 - `APP_HISTORY_MAX_AGE` – (opcjonalnie) maksymalny wiek danych w sekundach. Starsze wpisy
   będą usuwane podczas kolejnych zapisów.
+- `APP_HISTORY_MIN_INTERVAL` – minimalny odstęp (w sekundach) pomiędzy kolejnymi zapisami
+  historii. Domyślnie 60 sekund; ustaw `0`, aby zapisywać każdy snapshot niezależnie od czasu.
+
+Jeżeli nowy snapshot pojawi się szybciej niż wynika to z ustawienia `APP_HISTORY_MIN_INTERVAL`,
+aplikacja zaktualizuje ostatni rekord zamiast dopisywać kolejny. Dzięki temu historia zachowuje
+regularne odstępy czasowe i nie rozrasta się gwałtownie podczas częstego odpytywania.
 
 Katalog `var/` zawiera plik `.gitignore`, dzięki czemu dane historii nie trafiają do repozytorium.
 


### PR DESCRIPTION
## Summary
- allow configuring a minimum interval between history snapshots via APP_HISTORY_MIN_INTERVAL with a sensible default
- skip appending a new entry when the previous snapshot is too fresh and replace it instead
- document the new environment variable and the resulting rotation behaviour in the README

## Testing
- php -l src/history_storage.php

------
https://chatgpt.com/codex/tasks/task_e_68c9e736aa5c8331b0401c11e407f96f