### PR TITLE
Prevent refresh label overwrite on fetch completion

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -269,14 +269,16 @@ $serviceStatuses = $snapshot['services'];
         }
 
         if (elements.refreshLabel) {
-          if (customText) {
+          if (typeof customText === 'string' && customText.trim() !== '') {
             elements.refreshLabel.textContent = customText;
             return;
           }
 
-          const timestamp = new Date().toLocaleTimeString();
-          const prefix = manual ? 'Ręczne odświeżenie' : 'Ostatnie odświeżenie';
-          elements.refreshLabel.textContent = `${prefix}: ${timestamp}`;
+          if (loading) {
+            const timestamp = new Date().toLocaleTimeString();
+            const prefix = manual ? 'Trwa ręczne odświeżanie' : 'Trwa odświeżanie';
+            elements.refreshLabel.textContent = `${prefix} (${timestamp})...`;
+          }
         }
       };
 


### PR DESCRIPTION
## Summary
- update `setFetchingState` so the refresh label is only updated when a fetch starts or when forced text is provided
- ensure streaming/manual refresh flows keep button and class states while letting `updateLabelSuccess` own the final label text

## Testing
- node <<'NODE' …``` (simulation covering manual refresh, streaming connect, and error label preservation)


------
https://chatgpt.com/codex/tasks/task_e_68c9eabab1d48331894febda30d08a7a