### PR TITLE
Relocate theme toggle to page header

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -75,7 +75,12 @@ $serviceStatuses = $snapshot['services'];
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <h1>Witaj na mojej stronie! 🎉</h1>
+  <div class="page-header">
+    <h1>Witaj na mojej stronie! 🎉</h1>
+    <div class="theme-toggle theme-toggle--top">
+      <button type="button" data-role="theme-toggle" aria-pressed="false">Włącz tryb ciemny</button>
+    </div>
+  </div>
   <p>Ta strona działa na <strong>Raspberry Pi + Nginx + PHP</strong>.</p>
 
   <p>Aktualny czas serwera to: <strong data-role="server-time"><?= h($time); ?></strong></p>
@@ -142,9 +147,6 @@ $serviceStatuses = $snapshot['services'];
     </p>
 
     <div class="panel-footer">
-      <div class="theme-toggle">
-        <button type="button" data-role="theme-toggle" aria-pressed="false">Włącz tryb ciemny</button>
-      </div>
       <div class="status-refresh" data-role="refresh-container">
         <span data-role="refresh-label">Ostatnie odświeżenie: <?= h($snapshot['generatedAt']); ?></span>
         <button type="button" data-role="refresh-button">Odśwież teraz</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -96,6 +96,23 @@ h1 {
   color: var(--heading-primary);
 }
 
+.page-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.page-header h1 {
+  margin: 0;
+}
+
+.theme-toggle--top {
+  margin-left: auto;
+}
+
 p {
   font-size: 18px;
 }
@@ -433,8 +450,8 @@ footer {
 .panel-footer {
   margin-top: 20px;
   display: flex;
-  flex-direction: column;
-  gap: 12px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
 }
 
 .theme-toggle {


### PR DESCRIPTION
## Summary
- move the theme toggle button from the status panel footer into a new page header wrapper
- add header styling and adjust footer layout so the refresh section remains tidy without extra spacing
- ensure the JavaScript theme toggle reference continues to target the relocated button

## Testing
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68cb36c99e6c8331ab13128309109d47