### PR TITLE
Handle missing php-curl extension for Shelly integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ z poziomu przeglądarki.
 - Włącz interfejs RPC w oprogramowaniu Shelly oraz ewentualną autoryzację (klucz lub Basic Auth).
 - Dostęp do zakładki zabezpiecza ta sama ochrona HTTP Basic co resztę panelu.
 
+#### Wymagane rozszerzenia PHP
+
+- Moduł Shelly wykorzystuje funkcje biblioteki cURL, dlatego na serwerze musi być zainstalowane rozszerzenie `php-curl`.
+
 ### Użycie
 
 - Po zalogowaniu kliknij przycisk **Shelly** w nawigacji kart.

--- a/src/shelly_responder.php
+++ b/src/shelly_responder.php
@@ -46,6 +46,18 @@ function respondWithShellyList(array $devices): void
         return;
     }
 
+    if (!function_exists('curl_init')) {
+        sendShellyJsonResponse([
+            'generatedAt' => date(DATE_ATOM),
+            'count' => 0,
+            'hasErrors' => true,
+            'error' => 'environment:missing_curl',
+            'message' => 'Obsługa Shelly wymaga zainstalowania rozszerzenia PHP php-curl.',
+            'devices' => [],
+        ], 500);
+        return;
+    }
+
     $items = [];
     $hasErrors = false;
 
@@ -92,6 +104,14 @@ function respondWithShellyCommand(array $devices): void
             'error' => 'method_not_allowed',
             'message' => 'Ten endpoint obsługuje wyłącznie zapytania POST.',
         ], 405);
+        return;
+    }
+
+    if (!function_exists('curl_init')) {
+        sendShellyJsonResponse([
+            'error' => 'environment:missing_curl',
+            'message' => 'Obsługa Shelly wymaga zainstalowania rozszerzenia PHP php-curl.',
+        ], 500);
         return;
     }
 

--- a/src/shelly_rpc.php
+++ b/src/shelly_rpc.php
@@ -93,6 +93,14 @@ function setShellyRelayState(array $device, string $action): array
  */
 function performShellyRpcRequest(array $device, string $method, array $payload, string $context): array
 {
+    if (!function_exists('curl_init')) {
+        return [
+            'ok' => false,
+            'error' => 'environment:missing_curl',
+            'data' => null,
+        ];
+    }
+
     if (!isset($device['host'])) {
         return [
             'ok' => false,


### PR DESCRIPTION
## Summary
- return a clear environment:missing_curl error from the Shelly RPC helper when php-curl is unavailable
- surface the missing extension through Shelly list/command responses instead of triggering fatal errors
- document the php-curl requirement for the Shelly module in the README

## Testing
- php -l src/shelly_rpc.php
- php -l src/shelly_responder.php

------
https://chatgpt.com/codex/tasks/task_e_68cb42c482bc83319712f23e1d233c54