### PR TITLE
Add metric selection helpers for history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ w konfiguracji Shelly nie wpływają na działanie całego panelu.
 ## Historia metryk
 
 Panel może zapisywać kolejne snapshoty stanu do pliku JSON i prezentować historię
-na prostym wykresie temperatury CPU.
+na wykresach pokazujących m.in. temperaturę CPU, użycie pamięci RAM, zajętość dysku
+oraz obciążenie systemu.
 
 ### Konfiguracja zapisu
 
@@ -135,9 +136,12 @@ zwracanych elementów parametrem `limit`, np. `?status=history&limit=120`.
 
 ### Wykres w interfejsie
 
-Front-end rysuje wykres temperatury CPU z wykorzystaniem elementu SVG generowanego przez
-JavaScript. Wykorzystuje wyłącznie natywne możliwości przeglądarki, więc aplikacja nie ładuje
-żadnych bibliotek zewnętrznych (np. Chart.js) ani zasobów z CDN.
+Front-end rysuje wykresy metryk (domyślnie temperatury CPU) z wykorzystaniem elementu SVG
+generowanego przez JavaScript. Wykorzystuje wyłącznie natywne możliwości przeglądarki, więc
+aplikacja nie ładuje żadnych bibliotek zewnętrznych (np. Chart.js) ani zasobów z CDN.
+Pod wykresem znajdziesz przełącznik, który pozwala wybrać jedną z dostępnych metryk (temperatura,
+pamięć, dysk, obciążenie). Wybrana opcja jest zapisywana w `localStorage`, dlatego po odświeżeniu
+strony panel od razu pokazuje preferowany wskaźnik.
 Wykres aktualizuje się automatycznie po wczytaniu strony, ręcznym odświeżeniu oraz podczas pracy
 w trybie strumieniowym. Jeżeli historia jest wyłączona lub niedostępna, panel wyświetli
 odpowiedni komunikat. Wygląd i zachowanie wykresu możesz dopasować, modyfikując pliki

--- a/public/styles.css
+++ b/public/styles.css
@@ -591,9 +591,45 @@ footer {
 }
 
 .history-container h3 {
-  margin: 0 0 12px;
+  margin: 0 0 8px;
   color: var(--panel-heading);
   font-size: 18px;
+}
+
+.history-metric-switch {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.history-metric-button {
+  border: 1px solid var(--panel-border);
+  background: transparent;
+  color: var(--status-note);
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.history-metric-button:hover {
+  background: var(--metric-background);
+  color: var(--panel-heading);
+}
+
+.history-metric-button.is-active {
+  background: var(--button-background);
+  border-color: transparent;
+  color: var(--button-text);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+}
+
+.history-metric-button:focus-visible {
+  outline: 2px solid var(--button-background);
+  outline-offset: 2px;
 }
 
 .history-chart {


### PR DESCRIPTION
## Summary
- manage history metric selection state with helper functions, localStorage persistence, and button events
- refresh the history chart based on the selected metric with improved messaging and tooltip handling
- document the new metric switcher and styling updates for the history chart controls

## Testing
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68cbeedc61088331a17d4d7fcecad217