### PR TITLE
Allow configuring disk usage path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,29 @@ generowany ruch sieciowy. Interwał jest przekazywany również do front-endu, d
 panel może dopasować swoje komunikaty oraz zapasowe odświeżanie do realnego tempa
 strumienia.
 
+## Wybór monitorowanej partycji
+
+Domyślnie panel prezentuje zajętość głównej partycji systemowej (`/`). Jeżeli chcesz śledzić
+inny punkt montowania (np. dysk z danymi lub udział sieciowy), ustaw zmienną
+środowiskową:
+
+- `APP_DISK_USAGE_PATH` – absolutna ścieżka, dla której mają być liczone statystyki.
+
+Ścieżka musi istnieć w systemie oraz zaczynać się od `/`. W przypadku pustej lub
+niepoprawnej wartości aplikacja wróci do domyślnego katalogu głównego. Przykład
+konfiguracji dwóch instancji monitorujących różne partycje:
+
+```bash
+# instancja panelu monitorująca systemowe „root”
+export APP_DISK_USAGE_PATH="/"
+
+# drugi panel skierowany na wolumen z multimediami
+export APP_DISK_USAGE_PATH="/mnt/media"
+```
+
+Po zmianie zmiennej uruchom ponownie serwer WWW / PHP-FPM, aby nowa konfiguracja została
+uwzględniona.
+
 ## Sterowanie Shelly
 
 Panel zawiera dodatkową zakładkę pozwalającą monitorować i przełączać przekaźniki Shelly

--- a/src/status_snapshot.php
+++ b/src/status_snapshot.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 function collectStatusSnapshot(array $servicesToCheck): array
 {
     $now = new DateTimeImmutable('now');
+    $diskUsagePath = resolveDiskUsagePath();
 
     $snapshot = [
         'time' => $now->format('H:i:s'),
@@ -27,7 +28,7 @@ function collectStatusSnapshot(array $servicesToCheck): array
         'systemLoad' => getSystemLoad(),
         'uptime' => getUptime(),
         'memoryUsage' => getMemoryUsage(),
-        'diskUsage' => getDiskUsage(),
+        'diskUsage' => getDiskUsage($diskUsagePath),
         'services' => collectServiceStatuses($servicesToCheck),
     ];
 


### PR DESCRIPTION
## Summary
- add a helper that reads the APP_DISK_USAGE_PATH environment variable with validation and reuse it in disk usage metrics
- ensure status snapshot generation uses the resolved disk path
- document the new configuration option with examples in the README

## Testing
- php -l src/system_metrics.php
- php -l src/status_snapshot.php

------
https://chatgpt.com/codex/tasks/task_e_68cc54e987848331adca2373900c9e22