### PR TITLE
Improve secure token generation

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -76,16 +76,13 @@ if (handleStatusRequest($statusParam, $servicesToCheck)) {
     return;
 }
 
-$csrfToken = null;
-
 try {
-    $csrfToken = bin2hex(random_bytes(32));
+    $csrfToken = generateSecureToken(32, '[CSRF]');
 } catch (Throwable $exception) {
-    error_log(sprintf('[CSRF] Nie udało się wygenerować bezpiecznego tokenu: %s: %s', get_class($exception), $exception->getMessage()));
-}
-
-if ($csrfToken === null || $csrfToken === '') {
-    $csrfToken = hash('sha256', uniqid((string) mt_rand(), true));
+    header('Content-Type: text/plain; charset=utf-8');
+    http_response_code(500);
+    echo 'Internal Server Error';
+    return;
 }
 
 $isHttps = (

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -36,3 +36,66 @@ function formatDuration(int $seconds): string
 
     return implode(' ', $parts);
 }
+
+/**
+ * Generates a cryptographically secure random token encoded as hexadecimal string.
+ *
+ * @throws RuntimeException When no secure random source is available.
+ */
+function generateSecureToken(int $lengthBytes = 32, string $logPrefix = '[Token]'): string
+{
+    if ($lengthBytes <= 0) {
+        throw new InvalidArgumentException('Token length must be a positive integer.');
+    }
+
+    $logPrefix = trim($logPrefix);
+    if ($logPrefix === '') {
+        $logPrefix = '[Token]';
+    }
+    if (substr($logPrefix, -1) !== ' ') {
+        $logPrefix .= ' ';
+    }
+
+    try {
+        return bin2hex(random_bytes($lengthBytes));
+    } catch (Throwable $randomBytesException) {
+        error_log(sprintf(
+            '%sNie udało się wygenerować tokenu przy użyciu random_bytes(): %s: %s',
+            $logPrefix,
+            get_class($randomBytesException),
+            $randomBytesException->getMessage()
+        ));
+    }
+
+    if (function_exists('openssl_random_pseudo_bytes')) {
+        $strong = false;
+        try {
+            $opensslBytes = openssl_random_pseudo_bytes($lengthBytes, $strong);
+        } catch (Throwable $opensslException) {
+            error_log(sprintf(
+                '%sNie udało się wygenerować tokenu przy użyciu openssl_random_pseudo_bytes(): %s: %s',
+                $logPrefix,
+                get_class($opensslException),
+                $opensslException->getMessage()
+            ));
+            $opensslBytes = false;
+        }
+
+        if ($opensslBytes !== false) {
+            if ($strong) {
+                return bin2hex($opensslBytes);
+            }
+
+            error_log(sprintf(
+                '%sopenssl_random_pseudo_bytes() zwróciło bajty, które nie są kryptograficznie silne.',
+                $logPrefix
+            ));
+        }
+    } else {
+        error_log(sprintf('%sFunkcja openssl_random_pseudo_bytes() jest niedostępna.', $logPrefix));
+    }
+
+    error_log(sprintf('%sBrak kryptograficznie silnego generatora losowego.', $logPrefix));
+
+    throw new RuntimeException('Brak kryptograficznie silnego generatora losowego.');
+}


### PR DESCRIPTION
## Summary
- add a helper to generate cryptographically strong tokens with logging and fallbacks
- update the CSRF token generation to rely on the helper and fail safely when no secure entropy is available

## Testing
- php -l src/helpers.php
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68cca165b1dc8331ace95a83d42f86b0