### PR TITLE
Avoid Shelly list flicker during refresh

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -587,6 +587,17 @@ $streamInterval = getStatusStreamInterval();
           return;
         }
 
+        const hasDevices = shellyState.devices.length > 0;
+
+        if (shellyState.loading && hasDevices) {
+          container.classList.remove('is-loading');
+          container.classList.add('is-refreshing');
+          container.setAttribute('aria-busy', 'true');
+          updateShellyLastUpdate();
+          return;
+        }
+
+        container.classList.remove('is-refreshing');
         container.innerHTML = '';
 
         if (shellyState.loading) {

--- a/public/styles.css
+++ b/public/styles.css
@@ -231,6 +231,10 @@ footer {
   min-height: 80px;
 }
 
+.shelly-list.is-refreshing .shelly-device {
+  opacity: 0.95;
+}
+
 .shelly-loading,
 .shelly-empty {
   background: var(--metric-background);
@@ -246,7 +250,7 @@ footer {
   border-radius: 12px;
   padding: 16px;
   box-shadow: inset 0 0 0 1px var(--panel-border);
-  transition: box-shadow 0.2s ease, transform 0.1s ease;
+  transition: box-shadow 0.2s ease, transform 0.1s ease, opacity 0.2s ease;
 }
 
 .shelly-device:hover {


### PR DESCRIPTION
## Summary
- keep rendered Shelly device cards visible while a refresh request is in-flight
- add a lightweight visual state for background refreshes and smooth the card opacity transition

## Testing
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d421375f0883319fa4a082a89c8b49