### PR TITLE
Add aggregated status API for mobile clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,30 @@ Odpowiedź zawiera m.in. pola `enabled`, `maxEntries`, `maxAge`, `count` oraz ta
 z uporządkowanymi rekordami historii (z wartościami liczbowymi i etykietami). Możesz zawęzić liczbę
 zwracanych elementów parametrem `limit`, np. `?status=history&limit=120`.
 
+### Pakiet danych dla aplikacji mobilnych
+
+Jeżeli chcesz odtworzyć zawartość panelu w aplikacji mobilnej (np. na iOS), możesz pobrać wszystkie
+potrzebne informacje jednym zapytaniem:
+
+```
+GET /index.php?status=ios
+```
+
+Alias `status=app` działa identycznie. Odpowiedź JSON zawiera:
+
+- `generatedAt` oraz `streamInterval` – sygnaturę czasową odpowiedzi oraz interwał SSE wykorzystywany
+  przez panel WWW,
+- `snapshot` – bieżący stan urządzenia w takim samym formacie jak `?status=json`,
+- `history` – blok z konfiguracją i rekordami historii; możesz ograniczyć liczbę zwracanych wpisów
+  parametrem `limit`, identycznie jak w dedykowanym endpointzie historii,
+- `shelly` – listę urządzeń Shelly wraz z informacjami o ewentualnych błędach (`hasErrors`), flagą
+  `configError` informującą o problemach z konfiguracją oraz statusem HTTP (`httpStatus`) z jakim
+  odpowiedziałby samodzielny endpoint `?shelly=list`.
+
+Dodatkowe pola `error` i `message` pojawiają się, gdy na serwerze brakuje rozszerzenia `php-curl`
+lub wystąpił inny błąd środowiskowy. Pakiet korzysta z tej samej autoryzacji HTTP Basic co interfejs
+przeglądarkowy.
+
 ### Wykres w interfejsie
 
 Front-end rysuje wykresy metryk (domyślnie temperatury CPU) z wykorzystaniem elementu SVG

--- a/public/index.php
+++ b/public/index.php
@@ -72,7 +72,7 @@ if (handleShellyRequest($shellyDevices)) {
     return;
 }
 
-if (handleStatusRequest($statusParam, $servicesToCheck)) {
+if (handleStatusRequest($statusParam, $servicesToCheck, $shellyDevices, $shellyConfigError)) {
     return;
 }
 


### PR DESCRIPTION
## Summary
- add a bundled `?status=ios` / `?status=app` endpoint that returns the snapshot, history and Shelly status in a single payload for mobile clients
- refactor Shelly list handling into a reusable helper so the bundle can include Shelly details and configuration errors without duplicating code
- document the new mobile data package endpoint in the README

## Testing
- php -l public/index.php
- php -l src/status_responder.php
- php -l src/shelly_responder.php

------
https://chatgpt.com/codex/tasks/task_e_68d422fac8948331a1ed287ac397288c