### PR TITLE
Adjust Shelly power button layout

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -669,10 +669,13 @@ $streamInterval = getStatusStreamInterval();
             card.classList.add('is-busy');
           }
 
+          const body = document.createElement('div');
+          body.className = 'shelly-device__body';
+
           const title = document.createElement('h3');
           title.className = 'shelly-device__title';
           title.textContent = device.label || device.id;
-          card.appendChild(title);
+          body.appendChild(title);
 
           const stateLine = document.createElement('p');
           stateLine.className = 'shelly-device__state';
@@ -682,14 +685,16 @@ $streamInterval = getStatusStreamInterval();
           stateValue.textContent = formatShellyStateLabel(device.state);
           stateLine.textContent = 'Stan: ';
           stateLine.appendChild(stateValue);
-          card.appendChild(stateLine);
+          body.appendChild(stateLine);
 
           if (device.description) {
             const description = document.createElement('p');
             description.className = 'shelly-device__description';
             description.textContent = device.description;
-            card.appendChild(description);
+            body.appendChild(description);
           }
+
+          card.appendChild(body);
 
           const actions = document.createElement('div');
           actions.className = 'shelly-device__actions';

--- a/public/styles.css
+++ b/public/styles.css
@@ -224,7 +224,7 @@ footer {
 .shelly-list {
   display: grid;
   gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
 .shelly-list.is-loading {
@@ -250,6 +250,10 @@ footer {
   border-radius: 12px;
   padding: 16px;
   box-shadow: inset 0 0 0 1px var(--panel-border);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 16px;
   transition: box-shadow 0.2s ease, transform 0.1s ease, opacity 0.2s ease;
 }
 
@@ -267,12 +271,21 @@ footer {
 }
 
 .shelly-device__title {
-  margin: 0 0 8px;
+  margin: 0;
   color: var(--panel-heading);
 }
 
+
+.shelly-device__body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+  flex: 1 1 260px;
+}
+
 .shelly-device__state {
-  margin: 0 0 8px;
+  margin: 0;
   font-weight: 600;
 }
 
@@ -289,27 +302,34 @@ footer {
 }
 
 .shelly-device__description {
-  margin: 0 0 12px;
+  margin: 0;
   color: var(--status-note);
   font-size: 14px;
 }
 
 .shelly-device__actions {
   display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  margin-bottom: 12px;
+  align-items: stretch;
+  justify-content: flex-end;
+  margin: 0;
+  align-self: stretch;
+  min-width: 220px;
+  flex: 1 1 320px;
+  margin-left: auto;
 }
+
 
 .shelly-device__action {
   position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 52px;
-  height: 52px;
+  width: 100%;
+  height: 100%;
+  min-height: 160px;
+  padding: 0;
   border: none;
-  border-radius: 50%;
+  border-radius: 16px;
   background: var(--button-background);
   color: var(--button-text);
   cursor: pointer;
@@ -357,11 +377,12 @@ footer {
   transform: scale(0.9);
 }
 
+
 .icon-power {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.4rem;
+  font-size: 3.6rem;
   line-height: 1;
   pointer-events: none;
   transition: transform 0.25s ease;
@@ -408,7 +429,28 @@ footer {
   color: var(--status-error);
   font-size: 14px;
   font-weight: 600;
+  flex-basis: 100%;
 }
+
+
+@media (max-width: 700px) {
+  .shelly-device {
+    flex-direction: column;
+  }
+
+  .shelly-device__actions {
+    flex: 1 1 100%;
+    width: 100%;
+    max-width: none;
+    margin-left: 0;
+    min-width: 0;
+  }
+
+  .shelly-device__action {
+    min-height: 140px;
+  }
+}
+
 
 .metrics {
   display: grid;


### PR DESCRIPTION
## Summary
- switch Shelly device cards to a flexible two-column layout so the power control stays on the right edge
- let the action column expand to fill the available space and stack cleanly on narrow screens

## Testing
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d425a71ac8833194352460d6e94b1f