### PR TITLE
Reduce history chart dot size

### DIFF
--- a/public/js/history.js
+++ b/public/js/history.js
@@ -668,7 +668,7 @@ const renderHistoryChart = (elements, entries, metricId) => {
     const dot = createSvgElement('circle', {
       cx: point.x,
       cy: point.y,
-      r: 3,
+      r: 1,
       class: 'history-dot',
     });
     dotsGroup.appendChild(dot);

--- a/public/js/history.js
+++ b/public/js/history.js
@@ -668,7 +668,7 @@ const renderHistoryChart = (elements, entries, metricId) => {
     const dot = createSvgElement('circle', {
       cx: point.x,
       cy: point.y,
-      r: 4,
+      r: 3,
       class: 'history-dot',
     });
     dotsGroup.appendChild(dot);


### PR DESCRIPTION
## Summary
- decrease the rendered SVG point radius for history charts so the dots appear smaller

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d48580caa083318c25c1a51d30ca74