### PR TITLE
Replace Shelly action text with power icon

### DIFF
--- a/public/js/shelly.js
+++ b/public/js/shelly.js
@@ -291,8 +291,20 @@ export function createShellyController(elements, options = {}) {
       actionButton.dataset.role = 'shelly-action';
       actionButton.dataset.deviceId = device.id;
       actionButton.dataset.action = nextAction;
-      actionButton.textContent = nextAction === 'on' ? 'Włącz' : 'Wyłącz';
       actionButton.className = 'shelly-device__action';
+
+      const actionLabel = nextAction === 'on' ? 'Włącz' : 'Wyłącz';
+      actionButton.setAttribute('aria-label', actionLabel);
+      actionButton.title = actionLabel;
+
+      const icon = document.createElement('span');
+      icon.className = 'icon-power';
+      actionButton.appendChild(icon);
+
+      const srLabel = document.createElement('span');
+      srLabel.className = 'sr-only';
+      srLabel.textContent = actionLabel;
+      actionButton.appendChild(srLabel);
 
       if (!supportsFetch || configError) {
         actionButton.disabled = true;


### PR DESCRIPTION
## Summary
- replace Shelly device action button labels with an icon-based layout
- add accessible labels and tooltips so the action meaning remains clear for assistive tech and hover hints

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d486acadcc8331b9a02384869c60c7