### PR TITLE
Adjust mobile Shelly action button sizing

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -930,7 +930,12 @@ footer {
   }
 
   .shelly-device__action {
-    min-height: 120px;
+    min-height: 150px;
+    padding: 12px;
+  }
+
+  .shelly-device__action .icon-power {
+    font-size: 4.2rem;
   }
 
   .metric {


### PR DESCRIPTION
## Summary
- increase the Shelly action button hit area on small screens by boosting min-height and padding
- enlarge the power icon for the mobile button view to match the bigger touch target

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d48fd5a314833187b40b511884e573