### PR TITLE
Add RoomPi branding to header

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -126,7 +126,23 @@ $streamInterval = getStatusStreamInterval();
 <body data-csrf-token="<?= h($csrfToken); ?>" data-stream-interval="<?= h((string) $streamInterval); ?>">
   <div class="page-wrapper">
   <div class="page-header">
-    <h1>Witaj na mojej stronie! 🎉</h1>
+    <h1 class="page-brand" aria-label="RoomPi">
+      <svg class="page-brand__logo" viewBox="0 0 64 64" role="img" aria-labelledby="roompi-logo-title roompi-logo-desc">
+        <title id="roompi-logo-title">Logo RoomPi</title>
+        <desc id="roompi-logo-desc">Symbol pi with a raspberry in the middle representing the RoomPi project.</desc>
+        <path class="page-brand__pi" d="M8 12h48v9H40v31h-8V21H24v31h-8V21H8z"/>
+        <g class="page-brand__windows">
+          <rect x="18" y="27" width="6" height="10" rx="1" />
+          <rect x="40" y="27" width="6" height="10" rx="1" />
+        </g>
+        <g class="page-brand__berry">
+          <circle cx="32" cy="32" r="11" />
+          <circle class="page-brand__berry-highlight" cx="28.5" cy="27" r="4" />
+          <path class="page-brand__leaf" d="M32 18c3.8 0 6.6-2.4 7.7-5.7a9.9 9.9 0 0 0-7.7 3.7 9.9 9.9 0 0 0-7.7-3.7C25.4 15.6 28.2 18 32 18z" />
+        </g>
+      </svg>
+      <span class="page-brand__title">RoomPi</span>
+    </h1>
     <div class="theme-toggle theme-toggle--top">
       <button type="button" data-role="theme-toggle" aria-pressed="false">Włącz tryb ciemny</button>
     </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -12,6 +12,13 @@ body {
   --background: #e9eef5;
   --text-primary: #1d2433;
   --heading-primary: #0066cc;
+  --brand-title: #1d2433;
+  --brand-title-shadow: rgba(0, 0, 0, 0.08);
+  --logo-pi: #1d2433;
+  --logo-window: #ffffff;
+  --logo-berry: #d63a4c;
+  --logo-berry-highlight: rgba(255, 255, 255, 0.65);
+  --logo-leaf: #2f9e44;
   --panel-background: #ffffff;
   --panel-shadow: 0 8px 16px rgba(0, 0, 0, 0.08);
   --panel-heading: #0b5394;
@@ -66,6 +73,13 @@ body.theme-dark {
   --background: #050505;
   --text-primary: #f2f2f2;
   --heading-primary: #fafafa;
+  --brand-title: #f6f6f6;
+  --brand-title-shadow: rgba(0, 0, 0, 0.4);
+  --logo-pi: #f5f5f5;
+  --logo-window: #1d2433;
+  --logo-berry: #ff6b6b;
+  --logo-berry-highlight: rgba(255, 255, 255, 0.75);
+  --logo-leaf: #63e68a;
   --panel-background: #111111;
   --panel-shadow: 0 12px 32px rgba(0, 0, 0, 0.7);
   --panel-heading: #f5f5f5;
@@ -135,8 +149,44 @@ h1 {
   margin-bottom: 16px;
 }
 
-.page-header h1 {
+.page-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
   margin: 0;
+}
+
+.page-brand__logo {
+  width: 72px;
+  height: 72px;
+  flex-shrink: 0;
+}
+
+.page-brand__pi {
+  fill: var(--logo-pi);
+}
+
+.page-brand__windows rect {
+  fill: var(--logo-window);
+}
+
+.page-brand__berry circle {
+  fill: var(--logo-berry);
+}
+
+.page-brand__berry-highlight {
+  fill: var(--logo-berry-highlight);
+}
+
+.page-brand__leaf {
+  fill: var(--logo-leaf);
+}
+
+.page-brand__title {
+  font-size: clamp(30px, 4vw, 40px);
+  font-weight: 700;
+  color: var(--brand-title);
+  text-shadow: 0 2px 6px var(--brand-title-shadow);
 }
 
 .theme-toggle--top {


### PR DESCRIPTION
## Summary
- replace the generic greeting header with a RoomPi brand block that shows a Pi-themed logo and title
- implement an inline SVG logo that adapts its colors to the active light or dark theme
- extend the stylesheet with brand colors and layout rules for the new header presentation

## Testing
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d49175f410833191dbc8ef2ab8cd8e