### PR TITLE
Move Shelly reload button to panel footer

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -229,13 +229,13 @@ $streamInterval = getStatusStreamInterval();
   <section class="shelly-panel tab-panel" data-role="tab-panel" data-tab-panel="shelly" id="panel-shelly" role="tabpanel" aria-labelledby="tab-shelly" data-shelly-config-error="<?= $shellyConfigError ? 'true' : 'false'; ?>" hidden>
     <h2>Urządzenia Shelly</h2>
     <p class="shelly-intro">Steruj przekaźnikami Shelly dostępnych w Twojej sieci domowej bezpośrednio z tego panelu.</p>
-    <div class="shelly-toolbar">
-      <button type="button" data-role="shelly-reload">Odśwież listę</button>
-      <span class="shelly-last-update" data-role="shelly-last-update"></span>
-    </div>
     <p class="shelly-error" data-role="shelly-error" hidden></p>
     <p class="shelly-message" data-role="shelly-message">Przełącz na kartę „Shelly”, aby pobrać stan urządzeń.</p>
     <div class="shelly-list" data-role="shelly-list" aria-live="polite" aria-busy="false"></div>
+    <div class="shelly-toolbar">
+      <span class="shelly-last-update" data-role="shelly-last-update"></span>
+      <button type="button" data-role="shelly-reload">Odśwież listę</button>
+    </div>
   </section>
 
   <footer>

--- a/public/styles.css
+++ b/public/styles.css
@@ -284,7 +284,7 @@ footer {
   flex-wrap: wrap;
   align-items: center;
   gap: 12px;
-  margin-bottom: 12px;
+  margin-top: 16px;
 }
 
 .shelly-last-update {
@@ -694,6 +694,7 @@ footer {
   cursor: pointer;
   transition: background 0.2s ease, transform 0.1s ease;
   flex-shrink: 0;
+  margin-left: auto;
 }
 
 .status-refresh button:hover,


### PR DESCRIPTION
## Summary
- move the Shelly reload controls to the bottom of the panel so the button sits below the device list
- update Shelly toolbar styling to provide top spacing and keep the reload button aligned to the right in its new position

## Testing
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d5ba09232c8331af58925935714bbb