### PR TITLE
Add loading and empty states to dashboard tabs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -52,6 +52,39 @@ const isLoading = computed(
   () => snapshotQuery.isLoading.value || historyQuery.isLoading.value || shellyQuery.isLoading.value
 );
 
+const getErrorMessage = (error: unknown) => {
+  if (!error) {
+    return null;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  return 'Wystąpił nieznany błąd.';
+};
+
+const statusErrorMessage = computed(() =>
+  snapshotQuery.isError.value ? getErrorMessage(snapshotQuery.error.value) : null
+);
+const historyErrorMessage = computed(() =>
+  historyQuery.isError.value ? getErrorMessage(historyQuery.error.value) : null
+);
+const shellyErrorMessage = computed(() =>
+  shellyQuery.isError.value ? getErrorMessage(shellyQuery.error.value) : null
+);
+
+const statusIsLoading = computed(
+  () => snapshotQuery.isLoading.value || snapshotQuery.isFetching.value
+);
+const historyIsLoading = computed(
+  () => historyQuery.isLoading.value || historyQuery.isFetching.value
+);
+const shellyIsLoading = computed(
+  () => shellyQuery.isLoading.value || shellyQuery.isFetching.value
+);
+
 const lastUpdate = computed(() => {
   if (!snapshotQuery.data.value) {
     return null;
@@ -111,20 +144,77 @@ const refreshSnapshot = () => {
         </div>
       </header>
 
-      <StatusOverview
-        v-if="activeTab === 'status' && statusPayload"
-        v-bind="statusPayload"
-        @refresh="refreshSnapshot"
-      />
+      <section v-if="activeTab === 'status'">
+        <StatusOverview
+          v-if="statusPayload"
+          v-bind="statusPayload"
+          @refresh="refreshSnapshot"
+        />
+        <div
+          v-else-if="statusIsLoading"
+          class="rounded-3xl bg-panel-card/70 p-10 text-center text-panel-muted shadow-xl backdrop-blur"
+        >
+          Ładowanie danych dotyczących stanu Raspberry Pi...
+        </div>
+        <div
+          v-else
+          class="flex flex-col items-center gap-2 rounded-3xl bg-panel-card/70 p-10 text-center shadow-xl backdrop-blur"
+        >
+          <p class="text-base font-medium text-panel-text">
+            {{ statusErrorMessage ?? 'Brak danych do wyświetlenia dla zakładki Status.' }}
+          </p>
+          <p v-if="!statusErrorMessage" class="text-sm text-panel-muted">
+            Spróbuj ponownie odświeżyć dane lub sprawdź połączenie z API.
+          </p>
+        </div>
+      </section>
 
-      <HistoryChart
-        v-if="activeTab === 'history' && hasHistory"
-        :entries="historyEntries"
-        :active-metric="metric"
-        @metric-change="handleMetricChange"
-      />
+      <section v-else-if="activeTab === 'history'">
+        <HistoryChart
+          v-if="hasHistory && historyEntries.length"
+          :entries="historyEntries"
+          :active-metric="metric"
+          @metric-change="handleMetricChange"
+        />
+        <div
+          v-else-if="historyIsLoading"
+          class="rounded-3xl bg-panel-card/70 p-10 text-center text-panel-muted shadow-xl backdrop-blur"
+        >
+          Trwa ładowanie historii pomiarów...
+        </div>
+        <div
+          v-else
+          class="flex flex-col items-center gap-2 rounded-3xl bg-panel-card/70 p-10 text-center shadow-xl backdrop-blur"
+        >
+          <p class="text-base font-medium text-panel-text">
+            {{ historyErrorMessage ?? 'Brak danych historycznych do wyświetlenia.' }}
+          </p>
+          <p v-if="!historyErrorMessage" class="text-sm text-panel-muted">
+            Gdy tylko pojawią się nowe wpisy, zobaczysz je w tym miejscu.
+          </p>
+        </div>
+      </section>
 
-      <ShellyPanel v-if="activeTab === 'shelly' && hasShelly" :devices="shellyDevices" />
+      <section v-else>
+        <ShellyPanel v-if="hasShelly && shellyDevices.length" :devices="shellyDevices" />
+        <div
+          v-else-if="shellyIsLoading"
+          class="rounded-3xl bg-panel-card/70 p-10 text-center text-panel-muted shadow-xl backdrop-blur"
+        >
+          Ładowanie danych urządzeń Shelly...
+        </div>
+        <div
+          v-else
+          class="flex flex-col items-center gap-2 rounded-3xl bg-panel-card/70 p-10 text-center shadow-xl backdrop-blur"
+        >
+          <p class="text-base font-medium text-panel-text">
+            {{ shellyErrorMessage ?? 'Brak informacji o urządzeniach Shelly.' }}
+          </p>
+          <p v-if="!shellyErrorMessage" class="text-sm text-panel-muted">
+            Upewnij się, że integracja z Shelly jest poprawnie skonfigurowana.
+          </p>
+        </div>
+      </section>
     </div>
     <VueQueryDevtools :initial-is-open="false" />
   </main>


### PR DESCRIPTION
## Summary
- surface human-friendly error extraction for each dashboard query
- show loading, empty, and error fallback panels when tab data is unavailable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6902090a883318ad6d67122b5ae80